### PR TITLE
CI: Automate GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            CHANGELOG.md
+
       # 2. Scan Local Image with Trivy
       # Fail if Critical/High vulnerabilities are found
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## Changes
- Updated `release.yml` to automatically create a GitHub Release when a tag is pushed.
- Uses `softprops/action-gh-release@v2`.
- Auto-generates release notes and attaches `CHANGELOG.md`.