### PR TITLE
chore: release v2.1.6 (Security Patch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,10 @@ RUN apt-get update && apt-get install -y \
   libjpeg62-turbo \
   libgif7 \
   librsvg2-2 \
-  && npm install -g npm@latest \
+  && npm install -g tar@7.5.3 \
+  && rm -rf /usr/local/lib/node_modules/npm/node_modules/tar \
+  && cp -r /usr/local/lib/node_modules/tar /usr/local/lib/node_modules/npm/node_modules/ \
+  && rm -rf /usr/local/lib/node_modules/tar \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-redact",
-  "version": "2.1.3",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-redact",
-      "version": "2.1.3",
+      "version": "2.1.6",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/multipart": "^9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-redact",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-redact",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/multipart": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-redact",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-redact",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.6",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Bumps version to v2.1.6 and patches CVE-2026-23745 by securing the npm tar dependency. Fix verified locally with passing scan.