### PR TITLE
fix(docker): fix Docker image does not provide web services

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,22 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # API reverse proxy
+    location /api/ {
+        proxy_pass http://localhost:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+        client_max_body_size 50M;
+    }
+
     # Cache static assets
     location /assets {
         expires 1y;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:nginx]
+command=nginx -g 'daemon off;'
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/nginx.log
+stderr_logfile=/var/log/supervisor/nginx.error.log
+priority=10
+
+[program:api]
+command=npm run api
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/api.log
+stderr_logfile=/var/log/supervisor/api.error.log
+priority=20
+environment=PORT="3000",HOST="0.0.0.0"


### PR DESCRIPTION
In the currently published Docker image, only the last api stage is used, and no web stage is used, resulting in the image not providing web services, and only one API port of `3000` is available.

This PR creates a production stage that runs both Nginx and Node API services and uses Supervisord to manage both processes. Also use `/api/` reverse proxy to internal `3000` port, exposing only `8080` port for convenience.

The results run container (*`8080:8080`*) provides:

- Web Interface: `http://localhost:8080`
- API endpoint: `http://localhost:8080/api/redact`