### PR TITLE
fix(docker): single-image production stage via bash entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build & Dependencies
-FROM node:20-slim as builder
+FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install build dependencies for node-canvas (Debian)
@@ -20,7 +20,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Web (Nginx)
-FROM nginx:alpine as web
+FROM nginx:alpine AS web
 RUN apk add --no-cache curl
 RUN touch /var/run/nginx.pid && \
   chown -R nginx:nginx /var/run/nginx.pid && \
@@ -35,7 +35,7 @@ HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:8080/ || ex
 CMD ["nginx", "-g", "daemon off;"]
 
 # Stage 3: API (Node)
-FROM node:20-slim as api
+FROM node:20-slim AS api
 WORKDIR /app
 
 # Install runtime dependencies for node-canvas (Debian)
@@ -68,12 +68,48 @@ RUN npm install -g tsx \
 
 USER node
 EXPOSE 3000
-# wget is not in slim? use curl or node script? node:20-slim usually has curl? 
-# Let's check. Standard slim has minimal.
-# Installing curl/wget in api stage if missing.
-USER root
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
-USER node
-
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/health || exit 1
 CMD ["npm", "run", "api"]
+
+# Stage 4: Production — Single image, nginx (port 8080) + Node API (internal :3000)
+# Uses a lightweight bash entrypoint — no Python/supervisord needed.
+FROM node:20-slim AS production
+WORKDIR /app
+
+# Install nginx, curl (healthcheck), and canvas runtime deps
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+  nginx \
+  curl \
+  libcairo2 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libjpeg62-turbo \
+  libgif7 \
+  librsvg2-2 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy built frontend from builder → nginx html root
+RUN rm -rf /usr/share/nginx/html/*
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Use production nginx config (includes /api/ reverse proxy to :3000)
+COPY nginx-production.conf /etc/nginx/conf.d/default.conf
+
+# Copy node app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/tsconfig.json ./
+COPY package*.json ./
+
+# Install tsx globally
+RUN npm install -g tsx && rm -rf /root/.npm
+
+# Entrypoint: starts nginx + API via bash (no Python/supervisord needed)
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD curl -f http://localhost:8080/ && curl -f http://localhost:3000/health || exit 1
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ npm run cli -- internal-doc.jpg \
 
 ---
 
-The Docker API runs on port 3000 by default. It uses standard detection settings (Emails, IPs, Keys, PII) by default, but is **fully configurable** via the `settings` parameter.
+The Docker API is proxied through nginx and available on port `8080` at `/api/`. It uses standard detection settings (Emails, IPs, Keys, PII) by default, but is **fully configurable** via the `settings` parameter.
 
 👉 **[View Full API Documentation](docs/API.md)** for detailed usage, schema, and Python/Node.js examples.
 
 #### Quick Test (Curl)
 ```bash
-curl -X POST http://localhost:3000/redact \
+curl -X POST http://localhost:8080/api/redact \
   -F "image=@/path/to/doc.jpg" \
   -o redacted.png
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
-  webapp:
+  # Single-image production setup: nginx (UI) + Node API on port 8080
+  # Access: http://localhost:8080 (web), http://localhost:8080/api/redact (API)
+  autoredact:
     build:
       context: .
-      target: web
-    image: karantdev/autoredact:web
-    container_name: autoredact-web
+      target: production
+    image: karantdev/autoredact:latest
+    container_name: autoredact
     ports:
       - "8080:8080"
     restart: unless-stopped
@@ -16,19 +18,29 @@ services:
     security_opt:
       - no-new-privileges:true
 
-  api:
-    build:
-      context: .
-      target: api
-    image: karantdev/autoredact:api
-    container_name: autoredact-api
-    ports:
-      - "3000:3000"
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    security_opt:
-      - no-new-privileges:true
+  # --- Multi-service alternative (separate web + api containers) ---
+  # Uncomment below and remove the 'autoredact' service above to use this instead.
+  #
+  # webapp:
+  #   build:
+  #     context: .
+  #     target: web
+  #   image: karantdev/autoredact:web
+  #   container_name: autoredact-web
+  #   ports:
+  #     - "8080:8080"
+  #   restart: unless-stopped
+  #   security_opt:
+  #     - no-new-privileges:true
+  #
+  # api:
+  #   build:
+  #     context: .
+  #     target: api
+  #   image: karantdev/autoredact:api
+  #   container_name: autoredact-api
+  #   ports:
+  #     - "3000:3000"
+  #   restart: unless-stopped
+  #   security_opt:
+  #     - no-new-privileges:true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+cleanup() {
+    echo "[entrypoint] Shutting down services..."
+    kill "$NGINX_PID" "$API_PID" 2>/dev/null || true
+    wait "$NGINX_PID" "$API_PID" 2>/dev/null || true
+    echo "[entrypoint] Done."
+}
+trap cleanup EXIT TERM INT
+
+echo "[entrypoint] Starting nginx..."
+nginx -g "daemon off;" &
+NGINX_PID=$!
+
+echo "[entrypoint] Starting API server..."
+tsx /app/src/server.ts &
+API_PID=$!
+
+echo "[entrypoint] Services running — nginx PID=$NGINX_PID, API PID=$API_PID"
+echo "[entrypoint] Web UI + API available on port 8080"
+
+# Poll — exit container if either service dies
+while kill -0 "$NGINX_PID" 2>/dev/null && kill -0 "$API_PID" 2>/dev/null; do
+    sleep 2
+done
+
+echo "[entrypoint] A service exited unexpectedly. Stopping container."

--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -1,0 +1,36 @@
+server {
+    listen 8080;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip Compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
+    # Reverse proxy to Node API — strips /api prefix
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 300s;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location /assets {
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+}


### PR DESCRIPTION
Fixes the issue raised in #52 — the published Docker image only ran the Node API (last Dockerfile stage). This adds a `production` stage combining nginx + Node API, using a lightweight bash entrypoint instead of supervisord (no Python dependency needed). Tested locally: web UI returns 200, API proxied at `/api/` returns health JSON. Also updates README and docker-compose to reflect the new single-image architecture. Closes #52.